### PR TITLE
Avoid cookiecutter wrestling with changelog

### DIFF
--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -7,6 +7,7 @@
     "author_email": "your_email@gmail.com",
     "cicd": ["github", "gitlab"],
     "_copy_without_render": [
-        ".github/workflows"
+        ".github/workflows",
+        ".changelog.d"
     ]
 }


### PR DESCRIPTION
Hey @joamatab,

I have been running into problems with the `changelog_template.jinja` needed for towncrier. Seemingly cookiecutter was trying to fill the template leading to errors. I solved the problem by adding it to `_copy_without_render`.